### PR TITLE
Pass fake headers

### DIFF
--- a/MyQ.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/MyQ.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -277,7 +277,7 @@ class Plugin(indigo.PluginBase):
 
         payload = {'appId': self.appID, 'securityToken': 'null', 'username': self.username, 'password': self.password, 'culture': 'en'}
         login_url = self.service + '/Membership/ValidateUserWithCulture'
-	headers = {'User-Agent': userAgent}
+        headers = {'User-Agent': userAgent}
         try:
 #            response = requests.get(url)
             response = requests.get(login_url, params=payload, headers=headers)
@@ -313,8 +313,8 @@ class Plugin(indigo.PluginBase):
             return
 
         url =  self.service + '/api/UserDeviceDetails'
-	params = {'appId':self.appID, 'securityToken':self.securityToken}
-	headers = {'User-Agent': userAgent }
+        params = {'appId':self.appID, 'securityToken':self.securityToken}
+        headers = {'User-Agent': userAgent }
         try:
             response = requests.get(url, params=params, headers=headers)
         except requests.exceptions.RequestException as err:
@@ -385,8 +385,8 @@ class Plugin(indigo.PluginBase):
     def getDeviceName(self, doorID):
 
         url =  self.service + '/Device/getDeviceAttribute'
-	params = {'appId': self.appID, 'securityToken': self.securityToken, 'devId': doorID, 'name':'desc'}
-	headers = {'User-Agent': userAgent}
+        params = {'appId': self.appID, 'securityToken': self.securityToken, 'devId': doorID, 'name':'desc'}
+        headers = {'User-Agent': userAgent}
         try:
             response = requests.get(url, params=params, headers=headers)
         except requests.exceptions.RequestException as err:
@@ -403,8 +403,8 @@ class Plugin(indigo.PluginBase):
     def getDeviceState(self, doorID):
 
         url =  self.service + '/Device/getDeviceAttribute'
-	params = {'appID': self.appID, 'securityToken': self.securityToken, 'devId': doorID, 'name':'doorstate'}
-	headers = {'User-Agent': userAgent}
+        params = {'appID': self.appID, 'securityToken': self.securityToken, 'devId': doorID, 'name':'doorstate'}
+        headers = {'User-Agent': userAgent}
         try:
             response = requests.get(url, params=params, headers=headers)
         except requests.exceptions.RequestException as err:
@@ -448,7 +448,7 @@ class Plugin(indigo.PluginBase):
            'SecurityToken': self.securityToken
            }
         url = self.service + '/api/deviceattribute/putdeviceattribute'
-	headers = {'User-Agent': userAgent}
+        headers = {'User-Agent': userAgent}
         try:
             response = requests.put(url, data=payload, headers=headers)
         except requests.exceptions.RequestException as err:

--- a/MyQ.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/MyQ.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -46,6 +46,8 @@ kswitchOn   = 1
 
 doorStateNames = ["Unknown", "Open", "Closed", "Stopped", "Opening", "Closing", "Unknown", "Disconnected"]
 
+userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.116 Safari/537.36"
+
 ################################################################################
 class Plugin(indigo.PluginBase):
 
@@ -275,10 +277,10 @@ class Plugin(indigo.PluginBase):
 
         payload = {'appId': self.appID, 'securityToken': 'null', 'username': self.username, 'password': self.password, 'culture': 'en'}
         login_url = self.service + '/Membership/ValidateUserWithCulture'
-
+	headers = {'User-Agent': userAgent}
         try:
 #            response = requests.get(url)
-            response = requests.get(login_url, params=payload)
+            response = requests.get(login_url, params=payload, headers=headers)
             self.logger.debug(u"myqLogin: response = " + str(response))
             self.logger.debug(u"myqLogin: content = " + str(response.text))
         except requests.exceptions.RequestException as err:
@@ -310,9 +312,11 @@ class Plugin(indigo.PluginBase):
         if not self.securityToken:
             return
 
-        url =  self.service + '/api/UserDeviceDetails?appId=' + self.appID + '&securityToken=' + self.securityToken
+        url =  self.service + '/api/UserDeviceDetails'
+	params = {'appId':self.appID, 'securityToken':self.securityToken}
+	headers = {'User-Agent': userAgent }
         try:
-            response = requests.get(url)
+            response = requests.get(url, params=params, headers=headers)
         except requests.exceptions.RequestException as err:
             self.debugLog(u"getDevices: RequestException: " + str(err))
             return
@@ -380,9 +384,11 @@ class Plugin(indigo.PluginBase):
 
     def getDeviceName(self, doorID):
 
-        url =  self.service + '/Device/getDeviceAttribute?appId=' + self.appID + '&securityToken=' + self.securityToken + '&devId=' + doorID + '&name=desc'
+        url =  self.service + '/Device/getDeviceAttribute'
+	params = {'appId': self.appID, 'securityToken': self.securityToken, 'devId': doorID, 'name':'desc'}
+	headers = {'User-Agent': userAgent}
         try:
-            response = requests.get(url)
+            response = requests.get(url, params=params, headers=headers)
         except requests.exceptions.RequestException as err:
             self.debugLog(u"getDeviceName: RequestException: " + str(err))
             return ""
@@ -396,9 +402,11 @@ class Plugin(indigo.PluginBase):
 
     def getDeviceState(self, doorID):
 
-        url =  self.service + '/Device/getDeviceAttribute?appId=' + self.appID + '&securityToken=' + self.securityToken + '&devId=' + doorID + '&name=doorstate'
+        url =  self.service + '/Device/getDeviceAttribute'
+	params = {'appID': self.appID, 'securityToken': self.securityToken, 'devId': doorID, 'name':'doorstate'}
+	headers = {'User-Agent': userAgent}
         try:
-            response = requests.get(url)
+            response = requests.get(url, params=params, headers=headers)
         except requests.exceptions.RequestException as err:
             self.debugLog(u"getDeviceState: RequestException: " + str(err))
             return 0
@@ -440,8 +448,9 @@ class Plugin(indigo.PluginBase):
            'SecurityToken': self.securityToken
            }
         url = self.service + '/api/deviceattribute/putdeviceattribute'
+	headers = {'User-Agent': userAgent}
         try:
-            response = requests.put(url, data=payload)
+            response = requests.put(url, data=payload, headers=headers)
         except requests.exceptions.RequestException as err:
             self.debugLog(u"changeDevice: RequestException: " + str(err))
             return


### PR DESCRIPTION
Normalized all calls to requests.get() to use params and headers. This is a horrible hack, in that the user agent string is fixed. The bigger issue is that Chamberlain seems to not like programmatic API access? They're filtering for the python2.6 user agent string (among others, I assume). It is almost certain that they will change their system to block this string at some point.