### PR TITLE
Added support for I/O devices as the sensor

### DIFF
--- a/MyQ.indigoPlugin/Contents/Info.plist
+++ b/MyQ.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>PluginVersion</key>
-    <string>7.1.7</string>
+    <string>7.1.8</string>
     <key>ServerApiVersion</key>
     <string>2.0</string>
     <key>IwsApiVersion</key>

--- a/MyQ.indigoPlugin/Contents/Server Plugin/Devices.xml
+++ b/MyQ.indigoPlugin/Contents/Server Plugin/Devices.xml
@@ -8,7 +8,7 @@
             <Field id="address" type="textfield"  hidden="true" />
 			<Field id="sensor" type="menu" >
 				<Label>Sensor Device:</Label>
-				<List class="indigo.devices" filter="indigo.sensor" />
+				<List class="indigo.devices" filter="indigo.sensor, indigo.iodevice" />
 			</Field>
         </ConfigUI>
         <States>


### PR DESCRIPTION
You can now specify an I/O device as the sensor device. It always uses
binaryInput1 as the source state.